### PR TITLE
Suppress warnings in elixir 1.17

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/params.ex
+++ b/lib/params.ex
@@ -169,7 +169,7 @@ defmodule Params do
   end
 
   defp relation_partition(module, names) do
-    types = module.__changeset__
+    types = module.__changeset__()
 
     names
     |> Stream.map(fn x -> String.to_atom("#{x}") end)

--- a/lib/params.ex
+++ b/lib/params.ex
@@ -41,7 +41,7 @@ defmodule Params do
   Recursively traverses and transforms embedded changesets and skips keys that
   was not part of params given to changeset
   """
-  @spec to_map(Changeset.t) :: map
+  @spec to_map(Changeset.t()) :: map
   def to_map(%Changeset{data: %{__struct__: module}} = ch) do
     ecto_defaults = module |> plain_defaults_defined_by_ecto_schema
     params_defaults = module |> schema |> defaults
@@ -72,13 +72,14 @@ defmodule Params do
   data.login # => "foo"
   ```
   """
-  @spec data(Changeset.t) :: struct
+  @spec data(Changeset.t()) :: struct
   def data(%Changeset{data: data = %{__struct__: module}} = ch) do
     default_embeds = default_embeds_from_schema(module)
 
-    default = Enum.reduce(default_embeds, data, fn {k, v}, m ->
-      Map.put(m, k, Map.get(m, k) || v)
-    end)
+    default =
+      Enum.reduce(default_embeds, data, fn {k, v}, m ->
+        Map.put(m, k, Map.get(m, k) || v)
+      end)
 
     Enum.reduce(ch.changes, default, fn {k, v}, m ->
       case v do
@@ -103,12 +104,14 @@ defmodule Params do
     end
 
     case schema(module) do
-      nil -> %{}
+      nil ->
+        %{}
+
       schema ->
         schema
         |> Stream.filter(is_embed_default)
         |> Stream.map(default_embed)
-        |> Enum.into(struct(module) |> Map.from_struct)
+        |> Enum.into(struct(module) |> Map.from_struct())
     end
   end
 
@@ -143,7 +146,7 @@ defmodule Params do
     changeset
     |> Changeset.cast(params, required ++ optional)
     |> Changeset.validate_required(required)
-    |> cast_relations(required_relations, [required: true])
+    |> cast_relations(required_relations, required: true)
     |> cast_relations(optional_relations, [])
   end
 
@@ -158,11 +161,11 @@ defmodule Params do
   end
 
   defp change(%{__struct__: _} = model) do
-    model |> Changeset.change
+    model |> Changeset.change()
   end
 
   defp change(module) when is_atom(module) do
-    module |> struct |> Changeset.change
+    module |> struct |> Changeset.change()
   end
 
   defp relation_partition(module, names) do
@@ -174,6 +177,7 @@ defmodule Params do
       case Map.get(types, name) do
         {type, _} when type in @relations ->
           {fields, [{name, type} | relations]}
+
         _ ->
           {[name | fields], relations}
       end
@@ -194,33 +198,39 @@ defmodule Params do
   defp deep_merge_conflict(_k, %{} = m1, %{} = m2) do
     deep_merge(m1, m2)
   end
+
   defp deep_merge_conflict(_k, _v1, v2), do: v2
 
   defp defaults(params), do: defaults(params, %{}, [])
   defp defaults(params, acc, path)
   defp defaults([], acc, _path), do: acc
   defp defaults(nil, _acc, _path), do: %{}
+
   defp defaults([opts | rest], acc, path) when is_list(opts) do
     defaults([Enum.into(opts, %{}) | rest], acc, path)
   end
+
   defp defaults([%{name: name, embeds: embeds} | rest], acc, path) do
     acc = defaults(embeds, acc, [name | path])
     defaults(rest, acc, path)
   end
+
   defp defaults([%{name: name, default: value} | rest], acc, path) do
-    funs = [name | path]
-    |> Enum.reverse
-    |> Enum.map(fn nested_name ->
-      fn :get_and_update, data, next ->
-        with {nil, inner_data} <- next.(data[nested_name] || %{}),
-             data = Map.put(data, nested_name, inner_data),
-             do: {nil, data}
-      end
-    end)
+    funs =
+      [name | path]
+      |> Enum.reverse()
+      |> Enum.map(fn nested_name ->
+        fn :get_and_update, data, next ->
+          with {nil, inner_data} <- next.(data[nested_name] || %{}),
+               data = Map.put(data, nested_name, inner_data),
+               do: {nil, data}
+        end
+      end)
 
     acc = put_in(acc, funs, value)
     defaults(rest, acc, path)
   end
+
   defp defaults([%{} | rest], acc, path) do
     defaults(rest, acc, path)
   end
@@ -238,7 +248,7 @@ defmodule Params do
   defp plain_defaults_defined_by_ecto_schema(module) do
     module
     |> struct
-    |> Map.from_struct
+    |> Map.from_struct()
     |> Map.delete(:__meta__)
     |> Enum.reject(fn {_, v} -> is_nil(v) end)
     |> Enum.into(%{})

--- a/lib/params/behaviour.ex
+++ b/lib/params/behaviour.ex
@@ -1,8 +1,7 @@
 defmodule Params.Behaviour do
   @moduledoc false
 
-  @callback from(map, Keyword.t) :: Ecto.Changeset.t
-  @callback data(map, Keyword.t) :: {:ok, struct} | {:error, Ecto.Changeset.t}
-  @callback changeset(Ecto.Changeset.t, map) :: Ecto.Changeset.t
-
+  @callback from(map, Keyword.t()) :: Ecto.Changeset.t()
+  @callback data(map, Keyword.t()) :: {:ok, struct} | {:error, Ecto.Changeset.t()}
+  @callback changeset(Ecto.Changeset.t(), map) :: Ecto.Changeset.t()
 end

--- a/lib/params/schema.ex
+++ b/lib/params/schema.ex
@@ -47,7 +47,7 @@ defmodule Params.Schema do
   end
 
   @doc false
-  defmacro schema([do: definition]) do
+  defmacro schema(do: definition) do
     quote do
       Ecto.Schema.schema "params #{__MODULE__}" do
         unquote(definition)
@@ -67,13 +67,13 @@ defmodule Params.Schema do
     quote do
       Module.register_attribute(__MODULE__, :required, persist: true)
       Module.register_attribute(__MODULE__, :optional, persist: true)
-      Module.register_attribute(__MODULE__, :schema,   persist: true)
+      Module.register_attribute(__MODULE__, :schema, persist: true)
 
       @behaviour Params.Behaviour
 
       def from(params, options \\ []) when is_list(options) do
         on_cast = Keyword.get(options, :with, &__MODULE__.changeset(&1, &2))
-        __MODULE__ |> struct |> Ecto.Changeset.change |> on_cast.(params)
+        __MODULE__ |> struct |> Ecto.Changeset.change() |> on_cast.(params)
       end
 
       def data(params, options \\ []) when is_list(options) do
@@ -87,8 +87,7 @@ defmodule Params.Schema do
         Params.changeset(changeset, params)
       end
 
-      defoverridable [changeset: 2]
+      defoverridable changeset: 2
     end
   end
-
 end

--- a/test/params_test.exs
+++ b/test/params_test.exs
@@ -24,7 +24,9 @@ defmodule ParamsTest do
   end
 
   test "defaults to all optional fields" do
-    assert [:_id, :age, :name] == Params.optional(PetParams)
+    # the order of the map fields is not guaranteed in OTP 26+
+    # https://www.erlang.org/news/164#maps
+    assert [:_id, :age, :name] == Params.optional(PetParams) |> Enum.sort()
   end
 
   test "from returns a changeset" do
@@ -118,7 +120,9 @@ defmodule ParamsTest do
   end
 
   test "kitten module has list of optional fields" do
-    assert [:age_min, :age_max] = Params.optional(Params.ParamsTest.Kitten)
+    # the order of the map fields is not guaranteed in OTP 26+
+    # https://www.erlang.org/news/164#maps
+    assert [:age_max, :age_min] = Params.optional(Params.ParamsTest.Kitten) |> Enum.sort()
   end
 
   test "kitten method returns changeset" do
@@ -153,7 +157,9 @@ defmodule ParamsTest do
   end
 
   test "puppy module has list of optional fields" do
-    assert [:age_min, :age_max] = Params.optional(Params.ParamsTest.Puppy)
+    # the order of the map fields is not guaranteed in OTP 26+
+    # https://www.erlang.org/news/164#maps
+    assert [:age_max, :age_min] = Params.optional(Params.ParamsTest.Puppy) |> Enum.sort()
   end
 
   test "puppy method returns changeset" do
@@ -188,7 +194,9 @@ defmodule ParamsTest do
   end
 
   test "dragon module has list of optional fields" do
-    assert [:age_min, :age_max] = Params.optional(Params.ParamsTest.Dragon)
+    # the order of the map fields is not guaranteed in OTP 26+
+    # https://www.erlang.org/news/164#maps
+    assert [:age_max, :age_min] = Params.optional(Params.ParamsTest.Dragon) |> Enum.sort()
   end
 
   test "dragon method returns changeset" do

--- a/test/params_test.exs
+++ b/test/params_test.exs
@@ -2,30 +2,29 @@ defmodule ParamsTest do
   use ExUnit.Case
   use Params
 
-  alias  Ecto.Changeset
+  alias Ecto.Changeset
   import Ecto.Changeset
 
   defmodule PetParams do
     use Params.Schema
+
     schema do
-      field :name
-      field :age, :integer
+      field(:name)
+      field(:age, :integer)
     end
   end
 
   test "module has schema types" do
-    assert %{age: :integer,
-             name: :string,
-             _id: :binary_id} ==
-      PetParams.__changeset__
+    assert %{age: :integer, name: :string, _id: :binary_id} ==
+             PetParams.__changeset__()
   end
 
   test "defaults to no required fields" do
-    assert [] == Params.required PetParams
+    assert [] == Params.required(PetParams)
   end
 
   test "defaults to all optional fields" do
-    assert [:_id, :age, :name] == Params.optional PetParams
+    assert [:_id, :age, :name] == Params.optional(PetParams)
   end
 
   test "from returns a changeset" do
@@ -42,8 +41,8 @@ defmodule ParamsTest do
     use Params.Schema
     @required ~w(latitude longitude)
     schema do
-      field :latitude,  :float
-      field :longitude, :float
+      field(:latitude, :float)
+      field(:longitude, :float)
     end
   end
 
@@ -51,8 +50,8 @@ defmodule ParamsTest do
     use Params.Schema
     @required ~w(origin destination)
     schema do
-      embeds_one :origin, LocationParams
-      embeds_one :destination, LocationParams
+      embeds_one(:origin, LocationParams)
+      embeds_one(:destination, LocationParams)
     end
   end
 
@@ -78,7 +77,7 @@ defmodule ParamsTest do
   test "invalid if nested required missing" do
     params = %{
       "origin" => %{
-        "latitude" => 12.2,
+        "latitude" => 12.2
       },
       "destination" => %{
         "longitude" => 13.3
@@ -88,28 +87,31 @@ defmodule ParamsTest do
     assert %{valid?: false} = BusParams.from(params)
   end
 
-
   test "to_map gets map of struct except for _id" do
     params = %{
       "latitude" => 12.2,
       "longitude" => 13.3
     }
-    result = params
-              |> LocationParams.from
-              |> Params.to_map
+
+    result =
+      params
+      |> LocationParams.from()
+      |> Params.to_map()
 
     assert result == %{latitude: 12.2, longitude: 13.3}
   end
 
-  defparams kitten %{
-    breed!:  :string,
-    age_min: :integer,
-    age_max: :integer,
-    near_location!: %{
-      latitude: :float,
-      longitude: :float
-    }
-  }
+  defparams(
+    kitten(%{
+      breed!: :string,
+      age_min: :integer,
+      age_max: :integer,
+      near_location!: %{
+        latitude: :float,
+        longitude: :float
+      }
+    })
+  )
 
   test "kitten module has list of required fields" do
     assert [:near_location, :breed] = Params.required(Params.ParamsTest.Kitten)
@@ -133,15 +135,18 @@ defmodule ParamsTest do
         "longitude" => "-90.0"
       }
     }
+
     assert %Changeset{valid?: true} = kitten(params)
   end
 
-  defparams puppy %{
-    breed!:  :string,
-    age_min: :integer,
-    age_max: :integer,
-    near_location!: {:embeds_one, LocationParams}
-  }
+  defparams(
+    puppy(%{
+      breed!: :string,
+      age_min: :integer,
+      age_max: :integer,
+      near_location!: {:embeds_one, LocationParams}
+    })
+  )
 
   test "puppy module has list of required fields" do
     assert [:near_location, :breed] = Params.required(Params.ParamsTest.Puppy)
@@ -165,15 +170,18 @@ defmodule ParamsTest do
         "longitude" => "-90.0"
       }
     }
+
     assert %Changeset{valid?: true} = puppy(params)
   end
 
-  defparams dragon %{
-    breed!:  :string,
-    age_min: :integer,
-    age_max: :integer,
-    near_locations!: {:embeds_many, LocationParams}
-  }
+  defparams(
+    dragon(%{
+      breed!: :string,
+      age_min: :integer,
+      age_max: :integer,
+      near_locations!: {:embeds_many, LocationParams}
+    })
+  )
 
   test "dragon module has list of required fields" do
     assert [:near_locations, :breed] = Params.required(Params.ParamsTest.Dragon)
@@ -203,15 +211,14 @@ defmodule ParamsTest do
         }
       ]
     }
+
     assert %Changeset{valid?: true} = dragon(params)
   end
 
-  defparams kid(
-      %{
-        name: :string,
-        age: :integer
-      }) do
-
+  defparams kid(%{
+              name: :string,
+              age: :integer
+            }) do
     def custom(ch, params) do
       cast(ch, params, ~w(name age)a)
       |> validate_required([:name])
@@ -233,7 +240,7 @@ defmodule ParamsTest do
   end
 
   test "can obtain data from changeset" do
-    m = Params.data kid(%{name: "hugo", age: "5"})
+    m = Params.data(kid(%{name: "hugo", age: "5"}))
     assert "hugo" == m.name
     assert 5 == m.age
     assert nil == m._id
@@ -243,7 +250,7 @@ defmodule ParamsTest do
     @schema %{
       name: :string,
       near: %{
-        latitude:  :float,
+        latitude: :float,
         longitude: :float
       }
     }
@@ -271,16 +278,17 @@ defmodule ParamsTest do
   end
 
   defmodule ManyNames do
-    use  Params.Schema, %{names!: [%{name!: :string}]}
+    use Params.Schema, %{names!: [%{name!: :string}]}
   end
 
   test "can have array of embedded schemas" do
     assert %{valid?: true} = ch = ManyNames.from(%{names: [%{name: "Julio"}, %{name: "Cesar"}]})
-    assert ["Julio", "Cesar"] = ch |> Params.data |> Map.get(:names) |> Enum.map(&(&1.name))
+    assert ["Julio", "Cesar"] = ch |> Params.data() |> Map.get(:names) |> Enum.map(& &1.name)
   end
 
   defmodule Vowel do
     use Params.Schema, %{x: :string}
+
     def changeset(ch, params) do
       cast(ch, params, [:x])
       |> validate_required([:x])
@@ -296,9 +304,11 @@ defmodule ParamsTest do
     assert {:error, %Changeset{valid?: false}} = Vowel.data(%{"x" => "x"})
   end
 
-  defparams schema_options %{
-    foo: [field: :string, default: "FOO"]
-  }
+  defparams(
+    schema_options(%{
+      foo: [field: :string, default: "FOO"]
+    })
+  )
 
   test "can specify raw Ecto.Schema options like default using a keyword list" do
     ch = schema_options(%{})
@@ -313,19 +323,21 @@ defmodule ParamsTest do
     assert map == %{foo: "FOO"}
   end
 
-  defparams default_nested %{
-    foo: %{
-      bar: :string,
-      baz: :string
-    },
-    bat: %{
-      man: [field: :string, default: "BATMAN"],
-      wo: %{
-        man: [field: :string, default: "BATWOMAN"]
+  defparams(
+    default_nested(%{
+      foo: %{
+        bar: :string,
+        baz: :string
       },
-      mo: %{ vil: :string }
-    }
-  }
+      bat: %{
+        man: [field: :string, default: "BATMAN"],
+        wo: %{
+          man: [field: :string, default: "BATWOMAN"]
+        },
+        mo: %{vil: :string}
+      }
+    })
+  )
 
   test "embeds with defaults are not nil" do
     ch = default_nested(%{})
@@ -344,34 +356,35 @@ defmodule ParamsTest do
     result = Params.to_map(changeset)
 
     assert result == %{
-      bat: %{
-        man: "BATMAN",
-        wo: %{
-          man: "BATWOMAN"
-        }
-      }
-    }
+             bat: %{
+               man: "BATMAN",
+               wo: %{
+                 man: "BATWOMAN"
+               }
+             }
+           }
   end
 
   test "to_map works on nested schemas with default values" do
-    changeset = %{
-      bat: %{
-        man: "Bruce"
+    changeset =
+      %{
+        bat: %{
+          man: "Bruce"
+        }
       }
-    }
-    |> default_nested
+      |> default_nested
 
     assert changeset.valid?
     result = Params.to_map(changeset)
 
     assert result == %{
-      bat: %{
-        man: "Bruce",
-        wo: %{
-          man: "BATWOMAN"
-        }
-      }
-    }
+             bat: %{
+               man: "Bruce",
+               wo: %{
+                 man: "BATWOMAN"
+               }
+             }
+           }
   end
 
   defmodule DefaultNested do
@@ -382,12 +395,12 @@ defmodule ParamsTest do
       d: %{
         e: :string,
         f: :string,
-        g: [field: :string, default: "G"],
+        g: [field: :string, default: "G"]
       },
       h: %{
         i: :string,
         j: :string,
-        k: [field: :string, default: "K"],
+        k: [field: :string, default: "K"]
       },
       l: %{
         m: :string
@@ -397,49 +410,49 @@ defmodule ParamsTest do
           p: [field: :string, default: "P"]
         }
       }
-
     }
   end
 
   test "to_map only returns submitted fields" do
-    result = %{
-      a: "A",
-      d: %{
-        e: "E",
-        g: "g"
-      }
-    }
-    |> DefaultNested.from
-    |> Params.to_map
-
-    assert result == %{
-      a: "A",
-      c: "C",
-      d: %{
-        e: "E",
-        g: "g"
-      },
-      h: %{
-        k: "K"
-      },
-      n: %{
-        o: %{
-          p: "P"
+    result =
+      %{
+        a: "A",
+        d: %{
+          e: "E",
+          g: "g"
         }
       }
-    }
+      |> DefaultNested.from()
+      |> Params.to_map()
+
+    assert result == %{
+             a: "A",
+             c: "C",
+             d: %{
+               e: "E",
+               g: "g"
+             },
+             h: %{
+               k: "K"
+             },
+             n: %{
+               o: %{
+                 p: "P"
+               }
+             }
+           }
   end
 
   defmodule DefaultCountParams do
     use Params.Schema
 
     schema do
-      field :count, :integer, default: 1
+      field(:count, :integer, default: 1)
     end
   end
 
   test "use Params.Schema respects defaults" do
-     changeset = DefaultCountParams.from(%{})
-     assert %{count: 1} = Params.to_map(changeset)
+    changeset = DefaultCountParams.from(%{})
+    assert %{count: 1} = Params.to_map(changeset)
   end
 end


### PR DESCRIPTION
Fix warnings in elixir 1.17 like:

- using map.field notation (without parentheses) to invoke function `ParamsTest.StringArray.__changeset__()` is deprecated, you must add parentheses instead: remote.function()
- use Mix.Config is deprecated

And some tests were failed in OTP 26+ due to map key orders.
