### PR TITLE
Suppress warnings in elixir 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir: 1.17.x
+          - elixir: 1.18.x
             otp: 27.x
             lint: true
+          - elixir: 1.17.x
+            otp: 27.x
           - elixir: 1.17.x
             otp: 25.x
           - elixir: 1.16.x

--- a/lib/params/def.ex
+++ b/lib/params/def.ex
@@ -13,13 +13,14 @@ defmodule Params.Def do
         Code.eval_quoted(block, [], __ENV__)
       end
 
-      Module.eval_quoted(
-        __MODULE__,
+      Code.eval_quoted(
         quote do
           def unquote(name)(params, options \\ []) do
             unquote(module_name).from(params, options)
           end
-        end
+        end,
+        [],
+        module: __MODULE__
       )
     end
   end
@@ -33,13 +34,14 @@ defmodule Params.Def do
         Params.Def.defschema(schema)
       end
 
-      Module.eval_quoted(
-        __MODULE__,
+      Code.eval_quoted(
         quote do
           def unquote(name)(params) do
             unquote(module_name).from(params)
           end
-        end
+        end,
+        [],
+        module: __MODULE__
       )
     end
   end
@@ -48,7 +50,7 @@ defmodule Params.Def do
   defmacro defschema(schema) do
     quote bind_quoted: [schema: schema] do
       normalized_schema = Params.Def.normalize_schema(schema, __MODULE__)
-      Module.eval_quoted(__MODULE__, Params.Def.gen_root_schema(normalized_schema))
+      Code.eval_quoted(Params.Def.gen_root_schema(normalized_schema), [], module: __MODULE__)
 
       normalized_schema
       |> Params.Def.build_nested_schemas()


### PR DESCRIPTION
This PR includes changes to the CI config and refactoring to suppress compiler warnings in Elixir v1.18.

- Updated the Elixir version in the matrix configs to include Elixir v1.18.
- `Module.eval_quoted/2` is deprecated.
  - use `Code.eval_quoted/3`.
  - Ref. https://github.com/elixir-lang/elixir/commit/ff26a8fac61e24154876a75e21917cf5a47a93b7